### PR TITLE
chore: remove prettier deps

### DIFF
--- a/packages/crypto-lib/package.json
+++ b/packages/crypto-lib/package.json
@@ -21,7 +21,6 @@
     "@types/node": "^22.0.0",
     "@types/randombytes": "2.0.3",
     "npm-run-all2": "^7.0.0",
-    "prettier": "2.6.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `prettier` dependency from the `@delandlabs/crypto-lib` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->