### PR TITLE
🐛 fix: missing inner dep version after publish

### DIFF
--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -29,8 +29,14 @@ jobs:
           fi
           echo Version: $Version
           export VITE_RELEASE_VERSION=$Version
+
           yarn install --frozen-lockfile
+
+          # Replace * with actual version in package.json
+          node scripts/replaceVersions.js $Version
+          
           yarn build:all
+
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/crypto-lib
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-base
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-dfinity

--- a/.github/workflows/npm-sdk-publish.yml
+++ b/.github/workflows/npm-sdk-publish.yml
@@ -25,8 +25,14 @@ jobs:
           Version=$(git describe --tags --abbrev=0)
           echo Version: $Version
           export VITE_RELEASE_VERSION=$Version
+
           yarn install --frozen-lockfile
+
+          # Replace * with actual version in package.json
+          node scripts/replaceVersions.js $Version
+
           yarn build:all
+          
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/crypto-lib --access public
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-base --access public
           yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-dfinity --access public

--- a/packages/coin-base/package.json
+++ b/packages/coin-base/package.json
@@ -29,11 +29,11 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@delandlabs/crypto-lib": "*",
     "class-transformer": "^0.5.1",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@delandlabs/crypto-lib": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-dfinity/package.json
+++ b/packages/coin-dfinity/package.json
@@ -43,7 +43,6 @@
     "cborg": "^4.2.4"
   },
   "devDependencies": {
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-ethereum/package.json
+++ b/packages/coin-ethereum/package.json
@@ -29,10 +29,10 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@delandlabs/coin-base": "*",
     "ethers": "^6.13.1"
   },
   "devDependencies": {
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-kaspa/package.json
+++ b/packages/coin-kaspa/package.json
@@ -31,6 +31,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@delandlabs/crypto-lib": "*",
+    "@delandlabs/coin-base": "*",
     "buffer": "^6.0.3",
     "long": "^5.2.3",
     "nice-grpc-web": "^3.3.5",
@@ -39,8 +41,6 @@
     "websocket-heartbeat-js": "^1.1.3"
   },
   "devDependencies": {
-    "@delandlabs/crypto-lib": "*",
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-solana/package.json
+++ b/packages/coin-solana/package.json
@@ -36,7 +36,6 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-ton/package.json
+++ b/packages/coin-ton/package.json
@@ -29,6 +29,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@delandlabs/coin-base": "*",
     "@openproduct/web-sdk": "^0.23.0",
     "@orbs-network/ton-access": "^2.3.3",
     "@ton/core": "^0.59.0",
@@ -39,7 +40,6 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/coin-tron/package.json
+++ b/packages/coin-tron/package.json
@@ -29,11 +29,11 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@delandlabs/crypto-lib": "*",
+    "@delandlabs/coin-base": "*",
     "tronweb": "^6.0.0"
   },
   "devDependencies": {
-    "@delandlabs/crypto-lib": "*",
-    "@delandlabs/coin-base": "*",
     "@eslint/js": "^9.16.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",

--- a/packages/crypto-lib/tsconfig-base.json
+++ b/packages/crypto-lib/tsconfig-base.json
@@ -8,7 +8,7 @@
     "module": "ESNext",
     "strict": true,
     "declaration": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     /* Additional Checks */

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,6 +32,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@delandlabs/coin-base": "*",
+    "@delandlabs/coin-ton": "*",
     "@mixer/postmessage-rpc": "^1.1.4",
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
@@ -44,8 +46,6 @@
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
-    "@delandlabs/coin-base": "*",
-    "@delandlabs/coin-ton": "*",
     "@rollup/plugin-typescript": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/scripts/replaceVersions.js
+++ b/scripts/replaceVersions.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+const version = process.argv[2];
+if (!version) {
+  console.error('Version argument is required');
+  process.exit(1);
+}
+
+const packagesDir = path.resolve(__dirname, '../packages');
+
+fs.readdirSync(packagesDir).forEach(packageName => {
+  const packageJsonPath = path.join(packagesDir, packageName, 'package.json');
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    // Update dependencies to the new version if they are in the packages list
+    Object.keys(packageJson.dependencies || {}).forEach(dep => {
+      if (dep.startsWith('@delandlabs/')) {
+        packageJson.dependencies[dep] = version;
+      }
+    });
+
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+    console.log(`Updated ${packageJsonPath} with version ${version}`);
+  }
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package publishing processes for GitLab and npm with improved versioning and automation.
	- Introduced a script to update dependency versions in multiple `package.json` files.

- **Dependency Changes**
	- Shifted several dependencies from `devDependencies` to `dependencies` across multiple packages, reflecting their essential role in runtime functionality.

- **Configuration Changes**
	- Updated TypeScript configuration to disable source map generation for the `crypto-lib` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->