### PR TITLE
🐛 fix: fix imports and cleanup duplicate deps

### DIFF
--- a/packages/coin-base/package.json
+++ b/packages/coin-base/package.json
@@ -53,9 +53,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-dfinity/package.json
+++ b/packages/coin-dfinity/package.json
@@ -61,9 +61,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-ethereum/package.json
+++ b/packages/coin-ethereum/package.json
@@ -51,9 +51,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-kaspa/package.json
+++ b/packages/coin-kaspa/package.json
@@ -58,9 +58,6 @@
     "globals": "^15.12.0",
     "grpc-tools": "^1.12.4",
     "ts-proto": "^2.4.2",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-solana/package.json
+++ b/packages/coin-solana/package.json
@@ -39,8 +39,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@solana/web3.js": "^1.98.0",
     "@solana/spl-token": "^0.4.9",
+    "@solana/web3.js": "^1.98.0",
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
@@ -53,9 +53,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-ton/package.json
+++ b/packages/coin-ton/package.json
@@ -59,9 +59,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/coin-tron/package.json
+++ b/packages/coin-tron/package.json
@@ -53,9 +53,6 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "globals": "^15.12.0",
-    "typescript": "~5.7.0",
-    "typescript-eslint": "^8.16.0",
-    "vite": "^6.2.1",
-    "vitest": "^3.0.8"
+    "typescript-eslint": "^8.16.0"
   }
 }

--- a/packages/crypto-lib/package.json
+++ b/packages/crypto-lib/package.json
@@ -23,8 +23,7 @@
     "@types/randombytes": "2.0.3",
     "npm-run-all2": "^7.0.0",
     "rimraf": "^6.0.0",
-    "ts-node": "^10.7.0",
-    "typescript": "^5.0.0"
+    "ts-node": "^10.7.0"
   },
   "dependencies": {
     "@scure/base": "1.2.1",

--- a/packages/sdk/src/lib/types.ts
+++ b/packages/sdk/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { WalletAccount } from "@delandlabs/coin-base"
+import { WalletAccount } from "@delandlabs/coin-base/model"
 import { AuthenticatorType, HibitIdAssetType, HibitIdChainId, HibitIdErrorCode } from "./enums"
 import { TonConnectSignDataPayload, TonConnectSignDataResult, TonConnectTransactionPayload } from "./tonconnect/types"
 

--- a/packages/sdk/src/lib/wallet.ts
+++ b/packages/sdk/src/lib/wallet.ts
@@ -42,7 +42,7 @@ import {
 } from './enums';
 import { clamp, parseBalanceRequest, stringifyBalanceRequest } from './utils';
 import { TonConnectSignDataResult } from '@delandlabs/coin-ton';
-import { WalletAccount } from '@delandlabs/coin-base';
+import { WalletAccount } from '@delandlabs/coin-base/model';
 
 const LOGIN_SESSION_KEY = 'hibit-id-session';
 const BALANCE_POLL_INTERVAL = 5000;

--- a/packages/sdk/src/test/App.tsx
+++ b/packages/sdk/src/test/App.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from "react";
 import { HibitIdWallet } from "../lib/wallet";
 import { HibitIdAssetType, HibitIdChainId } from "../lib";
-import { WalletAccount } from "@delandlabs/coin-base";
+import { WalletAccount } from "@delandlabs/coin-base/model";
 import { BalanceChangeData } from "../lib/types";
 
 const App: FC = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,16 +1413,6 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
 
-"@vitest/expect@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/expect/-/expect-3.0.8.tgz#53c408180d6476c7363eb976dcaae8e7b1f1a078"
-  integrity sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==
-  dependencies:
-    "@vitest/spy" "3.0.8"
-    "@vitest/utils" "3.0.8"
-    chai "^5.2.0"
-    tinyrainbow "^2.0.0"
-
 "@vitest/expect@3.1.1":
   version "3.1.1"
   resolved "https://registry.npmmirror.com/@vitest/expect/-/expect-3.1.1.tgz#d64ddfdcf9e877d805e1eee67bd845bf0708c6c2"
@@ -1433,15 +1423,6 @@
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/mocker/-/mocker-3.0.8.tgz#01638859e7dd422a8aaf04ef63dca9e1bbb9838d"
-  integrity sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==
-  dependencies:
-    "@vitest/spy" "3.0.8"
-    estree-walker "^3.0.3"
-    magic-string "^0.30.17"
-
 "@vitest/mocker@3.1.1":
   version "3.1.1"
   resolved "https://registry.npmmirror.com/@vitest/mocker/-/mocker-3.1.1.tgz#7689d99f87498684c71e9fe9defdbd13ffb7f1ac"
@@ -1451,13 +1432,6 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.0.8", "@vitest/pretty-format@^3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-3.0.8.tgz#89f6111d141142689871f5a4e62ad679bb6b6357"
-  integrity sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==
-  dependencies:
-    tinyrainbow "^2.0.0"
-
 "@vitest/pretty-format@3.1.1", "@vitest/pretty-format@^3.1.1":
   version "3.1.1"
   resolved "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-3.1.1.tgz#5b4d577771daccfced47baf3bf026ad59b52c283"
@@ -1465,29 +1439,12 @@
   dependencies:
     tinyrainbow "^2.0.0"
 
-"@vitest/runner@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/runner/-/runner-3.0.8.tgz#dda7223c25a89a829a29c3f0c037a99e028a9c64"
-  integrity sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==
-  dependencies:
-    "@vitest/utils" "3.0.8"
-    pathe "^2.0.3"
-
 "@vitest/runner@3.1.1":
   version "3.1.1"
   resolved "https://registry.npmmirror.com/@vitest/runner/-/runner-3.1.1.tgz#76b598700737089d66c74272b2e1c94ca2891a49"
   integrity sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==
   dependencies:
     "@vitest/utils" "3.1.1"
-    pathe "^2.0.3"
-
-"@vitest/snapshot@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-3.0.8.tgz#b65d738c00ff052a323125ad7dfb001927049c78"
-  integrity sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==
-  dependencies:
-    "@vitest/pretty-format" "3.0.8"
-    magic-string "^0.30.17"
     pathe "^2.0.3"
 
 "@vitest/snapshot@3.1.1":
@@ -1499,28 +1456,12 @@
     magic-string "^0.30.17"
     pathe "^2.0.3"
 
-"@vitest/spy@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/spy/-/spy-3.0.8.tgz#2a31ce28858aae50286644d64f886c72d55ae2ce"
-  integrity sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==
-  dependencies:
-    tinyspy "^3.0.2"
-
 "@vitest/spy@3.1.1":
   version "3.1.1"
   resolved "https://registry.npmmirror.com/@vitest/spy/-/spy-3.1.1.tgz#deca0b025e151302ab514f38390fd7777e294837"
   integrity sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==
   dependencies:
     tinyspy "^3.0.2"
-
-"@vitest/utils@3.0.8":
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/@vitest/utils/-/utils-3.0.8.tgz#289277fbd8e733dff69cfa993c34665415c9b66b"
-  integrity sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==
-  dependencies:
-    "@vitest/pretty-format" "3.0.8"
-    loupe "^3.1.3"
-    tinyrainbow "^2.0.0"
 
 "@vitest/utils@3.1.1":
   version "3.1.1"
@@ -2790,11 +2731,6 @@ execa@~8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
-
-expect-type@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.1.0.tgz#a146e414250d13dfc49eafcfd1344a4060fa4c75"
-  integrity sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==
 
 expect-type@^1.2.0:
   version "1.2.1"
@@ -4721,11 +4657,6 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
-std-env@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.8.0.tgz#b56ffc1baf1a29dcc80a3bdf11d7fca7c315e7d5"
-  integrity sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==
-
 std-env@^3.8.1:
   version "3.9.0"
   resolved "https://registry.npmmirror.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
@@ -5187,7 +5118,7 @@ typescript-eslint@^8.16.0:
     "@typescript-eslint/parser" "8.19.0"
     "@typescript-eslint/utils" "8.19.0"
 
-typescript@^5.0.0, typescript@^5.4.5, typescript@~5.7.0:
+typescript@^5.4.5:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
@@ -5273,17 +5204,6 @@ vite-bundle-analyzer@^0.15.0:
   resolved "https://registry.yarnpkg.com/vite-bundle-analyzer/-/vite-bundle-analyzer-0.15.2.tgz#176cbe1dd04f3d5aef42de5338a0b447354e191e"
   integrity sha512-AwFOewhvf7EkTACa9c/inbxMrJOWwyVF4nUMITwN26lM5TAYkcnJC4KFgZXym3sYRAWe1Qgvk8X4OFTw4HPaJw==
 
-vite-node@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/vite-node/-/vite-node-3.0.8.tgz#69cd1e0b9c7c37a8e7ab3b87ce259cbbf9a7bd72"
-  integrity sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==
-  dependencies:
-    cac "^6.7.14"
-    debug "^4.4.0"
-    es-module-lexer "^1.6.0"
-    pathe "^2.0.3"
-    vite "^5.0.0 || ^6.0.0"
-
 vite-node@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmmirror.com/vite-node/-/vite-node-3.1.1.tgz#ad186c07859a6e5fca7c7f563e55fb11b16557bc"
@@ -5303,7 +5223,7 @@ vite-plugin-node-polyfills@^0.22.0:
     "@rollup/plugin-inject" "^5.0.5"
     node-stdlib-browser "^1.2.0"
 
-"vite@^5.0.0 || ^6.0.0", vite@^6.2.1:
+"vite@^5.0.0 || ^6.0.0":
   version "6.2.4"
   resolved "https://registry.npmmirror.com/vite/-/vite-6.2.4.tgz#05809de3f918fded87f73a838761995a4d66a680"
   integrity sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==
@@ -5324,32 +5244,6 @@ vite@^6.2.6:
     rollup "^4.30.1"
   optionalDependencies:
     fsevents "~2.3.3"
-
-vitest@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.npmmirror.com/vitest/-/vitest-3.0.8.tgz#2b85e689d3067cf3b8e174626ecfcb8b24be0785"
-  integrity sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==
-  dependencies:
-    "@vitest/expect" "3.0.8"
-    "@vitest/mocker" "3.0.8"
-    "@vitest/pretty-format" "^3.0.8"
-    "@vitest/runner" "3.0.8"
-    "@vitest/snapshot" "3.0.8"
-    "@vitest/spy" "3.0.8"
-    "@vitest/utils" "3.0.8"
-    chai "^5.2.0"
-    debug "^4.4.0"
-    expect-type "^1.1.0"
-    magic-string "^0.30.17"
-    pathe "^2.0.3"
-    std-env "^3.8.0"
-    tinybench "^2.9.0"
-    tinyexec "^0.3.2"
-    tinypool "^1.0.2"
-    tinyrainbow "^2.0.0"
-    vite "^5.0.0 || ^6.0.0"
-    vite-node "3.0.8"
-    why-is-node-running "^2.3.0"
 
 vitest@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed several development dependencies across multiple packages, including TypeScript, Vite, Vitest, and duplicate TypeScript ESLint entries, reducing the number of development tools used.
- **Refactor**
  - Updated import paths for a specific type in the SDK package to improve internal consistency. 

No changes to user-facing features or exported/public entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->