### PR TITLE
chore: update ICP explorer URLs to icexplorer.io

### DIFF
--- a/packages/coin-dfinity/src/chains.ts
+++ b/packages/coin-dfinity/src/chains.ts
@@ -11,15 +11,15 @@ export const Dfinity: ChainInfo = {
   isNativeGas: false,
   ecosystem: Ecosystem.IC,
   supportedSignaturesSchemas: [WalletSignatureSchema.IcpEddsa],
-  explorer: 'https://dashboard.internetcomputer.org',
+  explorer: 'https://www.icexplorer.io',
   rpcUrls: ['https://ic0.app'],
   getTxLink: (txId: string) => {
     if (!txId) return '';
     const hash = txId.startsWith('0x') ? txId.slice(2) : txId;
-    return `https://dashboard.internetcomputer.org/transaction/${hash}`;
+    return `https://www.icexplorer.io/transactions/details/${hash}`;
   },
   getAddressLink: (address: string) => {
     if (!address) return '';
-    return `https://dashboard.internetcomputer.org/account/${address}`;
+    return `https://www.icexplorer.io/address/details/${address}`;
   }
 };


### PR DESCRIPTION
## Summary
- Updated ICP blockchain explorer URLs from dashboard.internetcomputer.org to www.icexplorer.io
- Updated transaction and address URL patterns to match the new explorer format

## Changes
- Explorer base URL: `https://dashboard.internetcomputer.org` → `https://www.icexplorer.io`
- Transaction URL: `/transaction/{hash}` → `/transactions/details/{hash}`
- Address URL: `/account/{address}` → `/address/details/{address}`

## Test plan
- [ ] Verify explorer links work correctly for ICP transactions
- [ ] Verify explorer links work correctly for ICP addresses
- [ ] Ensure no breaking changes for existing integrations

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated blockchain explorer links for the Internet Computer (Dfinity) to use the new icexplorer.io URLs for transactions and addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->