### PR TITLE
feat: add Kasplex L2 testnet and comment out Kaia/IGRA networks

### DIFF
--- a/packages/coin-base/src/types.ts
+++ b/packages/coin-base/src/types.ts
@@ -69,8 +69,9 @@ export class ChainNetwork {
   static EvmPantaNet = new ChainNetwork(331n);
   static EvmNeoXNet = new ChainNetwork(47763n);
   static EvmNeoXTestNet = new ChainNetwork(12227332n);
-  static EvmKaiaNet = new ChainNetwork(8217n);
-  static EvmKaiaKairosTestNet = new ChainNetwork(1001n);
+  // Kaia/IGRA networks - commented for future use
+  // static EvmKaiaNet = new ChainNetwork(8217n);
+  // static EvmKaiaKairosTestNet = new ChainNetwork(1001n);
 
   static SolanaMainNet = new ChainNetwork(0x3n);
   static SolanaTestNet = new ChainNetwork(0x2n);
@@ -86,6 +87,7 @@ export class ChainNetwork {
 
   static KaspaMainNet = new ChainNetwork(0n);
   static KaspaTestNet = new ChainNetwork(1n);
+  static EvmKasplexL2TestNet = new ChainNetwork(0xc655458fn);
 
   static fromString(value: string): ChainNetwork | null {
     if (!value) {

--- a/packages/coin-ethereum/src/chains.ts
+++ b/packages/coin-ethereum/src/chains.ts
@@ -265,32 +265,48 @@ export const EthereumNeoXTestnet: ChainInfo = {
   ecosystem: Ecosystem.EVM
 };
 
-export const EthereumKaia: ChainInfo = {
-  chainId: new ChainId(Chain.Ethereum, ChainNetwork.EvmKaiaNet),
-  name: 'Igra',
-  fullName: 'Igra Mainnet',
-  icon: '/chain-icons/Igra.png',
-  nativeAssetSymbol: 'KAIA',
+// IGRA configurations (mapped to Kaia) - commented for future use
+// export const EthereumKaia: ChainInfo = {
+//   chainId: new ChainId(Chain.Ethereum, ChainNetwork.EvmKaiaNet),
+//   name: 'Igra',
+//   fullName: 'Igra Mainnet',
+//   icon: '/chain-icons/Igra.png',
+//   nativeAssetSymbol: 'KAIA',
+//   nativeAssetDecimals: 18,
+//   supportedSignaturesSchemas: [WalletSignatureSchema.EvmEcdsa],
+//   explorer: 'https://kaiascan.io/',
+//   rpcUrls: ['https://public-en.node.kaia.io'],
+//   wsRpcUrls: ['wss://klaytn.drpc.org'],
+//   isMainnet: true,
+//   isNativeGas: true,
+//   ecosystem: Ecosystem.Kaspa
+// };
+// export const EthereumKaiaTestnet: ChainInfo = {
+//   chainId: new ChainId(Chain.Ethereum, ChainNetwork.EvmKaiaKairosTestNet),
+//   name: 'Igra Testnet',
+//   fullName: 'Igra Testnet',
+//   icon: '/chain-icons/Igra.png',
+//   nativeAssetSymbol: 'KAIA',
+//   nativeAssetDecimals: 18,
+//   supportedSignaturesSchemas: [WalletSignatureSchema.EvmEcdsa],
+//   explorer: 'https://kairos.kaiascan.io/',
+//   rpcUrls: ['https://public-en-kairos.node.kaia.io'],
+//   wsRpcUrls: ['wss://responsive-green-emerald.kaia-kairos.quiknode.pro'],
+//   isMainnet: false,
+//   isNativeGas: true,
+//   ecosystem: Ecosystem.Kaspa
+// };
+
+export const EthereumKasplexL2Testnet: ChainInfo = {
+  chainId: new ChainId(Chain.Ethereum, ChainNetwork.EvmKasplexL2TestNet),
+  name: 'Kasplex Network Testnet',
+  fullName: 'Kasplex Network Testnet',
+  icon: '/chain-icons/Kasplex.png',
+  nativeAssetSymbol: 'KAS',
   nativeAssetDecimals: 18,
   supportedSignaturesSchemas: [WalletSignatureSchema.EvmEcdsa],
-  explorer: 'https://kaiascan.io/',
-  rpcUrls: ['https://public-en.node.kaia.io'],
-  wsRpcUrls: ['wss://klaytn.drpc.org'],
-  isMainnet: true,
-  isNativeGas: true,
-  ecosystem: Ecosystem.Kaspa
-};
-export const EthereumKaiaTestnet: ChainInfo = {
-  chainId: new ChainId(Chain.Ethereum, ChainNetwork.EvmKaiaKairosTestNet),
-  name: 'Igra Testnet',
-  fullName: 'Igra Testnet',
-  icon: '/chain-icons/Igra.png',
-  nativeAssetSymbol: 'KAIA',
-  nativeAssetDecimals: 18,
-  supportedSignaturesSchemas: [WalletSignatureSchema.EvmEcdsa],
-  explorer: 'https://kairos.kaiascan.io/',
-  rpcUrls: ['https://public-en-kairos.node.kaia.io'],
-  wsRpcUrls: ['wss://responsive-green-emerald.kaia-kairos.quiknode.pro'],
+  explorer: 'https://frontend.kasplextest.xyz',
+  rpcUrls: ['https://rpc.kasplextest.xyz'],
   isMainnet: false,
   isNativeGas: true,
   ecosystem: Ecosystem.Kaspa

--- a/packages/sdk/src/lib/enums.ts
+++ b/packages/sdk/src/lib/enums.ts
@@ -72,6 +72,7 @@ export enum HibitIdChainId {
   EthereumPanta = '60_331',
   EthereumNeoX = '60_47763',
   EthereumNeoXTestnet = '60_12227332',
+  EthereumKasplexL2Testnet = '60_3327681135',
 
   SolanaMainnet = '501_3',
   SolanaTestnet = '501_2',


### PR DESCRIPTION
## Summary
- Added Kasplex L2 testnet support with official network configuration
- Commented out Kaia/IGRA network configurations for future use (as requested)
- Updated all related chain network types and enums

## Changes
### Added
- Kasplex L2 testnet configuration:
  - Network ID: `0xc655458f` (3327681135)
  - Native token: KAS (Bridged Kas)
  - Decimals: 18
  - RPC URL: https://rpc.kasplextest.xyz
  - Explorer: https://frontend.kasplextest.xyz
  - Gas Price: 2000 GWEI

### Modified
- Commented out Kaia/IGRA mainnet and testnet configurations
- Preserved IGRA branding with Kaia logo as requested
- Updated chain network static types
- Updated HibitIdChainId enum

## Test plan
- [ ] Build all packages successfully
- [ ] Verify Kasplex L2 testnet connection works
- [ ] Confirm Kaia networks are properly commented out
- [ ] No breaking changes for existing integrations

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kasplex L2 Testnet network, including its configuration and identification across the platform.

* **Chores**
  * Disabled previous Kaia network options, which are now reserved for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->