### PR TITLE
fix: remove unnecessary rm .npmrc command from npm publish workflow

### DIFF
--- a/.github/workflows/npm-sdk-publish.yml
+++ b/.github/workflows/npm-sdk-publish.yml
@@ -16,7 +16,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: yarn
       - run: |
-          rm .npmrc
           npm config set ${REGISTRY}:_authToken ${{ secrets.NPM_PACKAGE_TOKEN }}
           npm config set @delandlabs:registry https:${REGISTRY}
         env:


### PR DESCRIPTION
## Problem
The npm publish workflow is failing because it tries to remove `.npmrc` file which was already deleted in PR #356.

Error: `rm: cannot remove '.npmrc': No such file or directory`

## Solution
Remove the `rm .npmrc` command from the workflow since the file no longer exists.

## Test plan
- [ ] Workflow should complete without errors
- [ ] NPM packages should be published successfully

## Related
- PR #356 removed the `.npmrc` file
- This is blocking npm package publishing

🤖 Generated with [Claude Code](https://claude.ai/code)