### PR TITLE
chore: rename package from @delandlabs/hibit-id-wallet-sdk to hibit-id-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "build:coin-base": "turbo run @delandlabs/coin-base#build",
-    "dev:sdk": "turbo run dev --filter=@delandlabs/hibit-id-wallet-sdk",
-    "build:sdk": "turbo run @delandlabs/hibit-id-wallet-sdk#build",
+    "dev:sdk": "turbo run dev --filter=hibit-id-sdk",
+    "build:sdk": "turbo run hibit-id-sdk#build",
     "test:coin-kaspa": "turbo run @delandlabs/coin-kaspa#test",
     "build:coin-kaspa": "turbo run @delandlabs/coin-kaspa#build",
     "build:coin-ethereum": "turbo run @delandlabs/coin-ethereum#build",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -33,7 +33,7 @@ It supports a variety of popular third-party login methods which links user's We
 ## Install SDK
 
 ```bash
-yarn add @delandlabs/hibit-id-wallet-sdk
+yarn add hibit-id-sdk
 ```
 
 ## Usage
@@ -44,9 +44,9 @@ import {
   HibitIdChainId,
   WalletAccount,
   HibitIdAssetType,
-} from "@delandlabs/hibit-id-wallet-sdk"
+} from "hibit-id-sdk"
 // remember to import styles for the wallet
-import '@delandlabs/hibit-id-wallet-sdk/dist/style.css';
+import 'hibit-id-sdk/dist/style.css';
 
 // init hibitid wallet
 const hibitId = new HibitIdWallet({

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@delandlabs/hibit-id-wallet-sdk",
+  "name": "hibit-id-sdk",
   "private": false,
   "version": "1.0.0",
   "type": "module",
   "files": [
     "dist"
   ],
-  "main": "./dist/hibit-id-wallet-sdk.umd.cjs",
-  "module": "./dist/hibit-id-wallet-sdk.js",
+  "main": "./dist/hibit-id-sdk.umd.cjs",
+  "module": "./dist/hibit-id-sdk.js",
   "types": "dist/lib/index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/lib/index.d.ts",
-        "default": "./dist/hibit-id-wallet-sdk.js"
+        "default": "./dist/hibit-id-sdk.js"
       },
       "require": {
         "types": "./dist/lib/index.d.ts",
-        "default": "./dist/hibit-id-wallet-sdk.umd.cjs"
+        "default": "./dist/hibit-id-sdk.umd.cjs"
       }
     },
     "./dist/style.css": {
-      "import": "./dist/hibit-id-wallet-sdk.css",
-      "require": "./dist/hibit-id-wallet-sdk.css"
+      "import": "./dist/hibit-id-sdk.css",
+      "require": "./dist/hibit-id-sdk.css"
     }
   },
   "scripts": {

--- a/packages/sdk/vite.config.ts
+++ b/packages/sdk/vite.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
     lib: {
       // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'src/lib/index.ts'),
-      name: 'HibitIDWalletSdk',
+      name: 'HibitIDSdk',
       // the proper extensions will be added
-      fileName: 'hibit-id-wallet-sdk'
+      fileName: 'hibit-id-sdk'
     },
     commonjsOptions: {
       transformMixedEsModules: true,

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,7 @@
       "dependsOn": ["@delandlabs/coin-base#build"],
       "outputs": ["dist/**"]
     },
-    "@delandlabs/hibit-id-wallet-sdk#build": {
+    "hibit-id-sdk#build": {
       "env": ["VITE_*"],
       "dependsOn": ["@delandlabs/coin-base#build", "@delandlabs/coin-ton#build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Summary
Rename the npm package from `@delandlabs/hibit-id-wallet-sdk` to `hibit-id-sdk` for simplicity and better developer experience.

## Changes
- Updated package name in `packages/sdk/package.json`
- Updated build output filenames (from `hibit-id-wallet-sdk.*` to `hibit-id-sdk.*`)
- Updated Vite configuration library name
- Updated turbo.json task references
- Updated documentation and examples in README.md

## Migration Guide
For existing users, update your imports:

```diff
- import { HibitIdWallet } from "@delandlabs/hibit-id-wallet-sdk"
- import '@delandlabs/hibit-id-wallet-sdk/dist/style.css';
+ import { HibitIdWallet } from "hibit-id-sdk"
+ import 'hibit-id-sdk/dist/style.css';
```

Install the new package:
```bash
# Remove old package
yarn remove @delandlabs/hibit-id-wallet-sdk

# Add new package
yarn add hibit-id-sdk
```

## Breaking Change
This is a breaking change as the package name has changed. Users will need to update their imports and reinstall the package.

🤖 Generated with [Claude Code](https://claude.ai/code)