### PR TITLE
fix: fix npm publish workflow git tag retrieval

### DIFF
--- a/.github/workflows/npm-sdk-publish.yml
+++ b/.github/workflows/npm-sdk-publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -21,7 +23,12 @@ jobs:
         env:
           REGISTRY: //registry.npmjs.org/
       - run: |
-          Version=$(git describe --tags --abbrev=0)
+          if [ "${{ github.event_name }}" = "release" ]; then
+            Version=$(git describe --tags --abbrev=0)
+          else
+            # For branch pushes, use a dev version
+            Version=0.0.0-dev.$(date +"%Y%m%d%H%M%S")
+          fi
           echo Version: $Version
           export VITE_RELEASE_VERSION=$Version
 


### PR DESCRIPTION
## Problem
The npm publish workflow failed with error when trying to get git tags:
```
fatal: No names found, cannot describe anything
```

This happens when:
1. The workflow is triggered by push to `npm-release` branch (not a release)
2. The checkout action doesn't fetch full git history and tags

## Solution
1. **Add `fetch-depth: 0`** to checkout action to fetch all git history including tags
2. **Handle missing tags gracefully**:
   - For GitHub releases: Use tag version (e.g., `2.4.1`)
   - For branch pushes: Use dev version (e.g., `0.0.0-dev.20241218123456`)

## Test Plan
- [ ] Push to npm-release branch should generate dev version
- [ ] GitHub release should use proper tag version
- [ ] No more "cannot describe anything" errors

## Related
- Failed workflow: https://github.com/Deland-Labs/hibit-id-sdk/actions/runs/16367981400

🤖 Generated with [Claude Code](https://claude.ai/code)