### PR TITLE
fix: remove conflicting @delandlabs registry configuration

### DIFF
--- a/.github/workflows/npm-sdk-publish.yml
+++ b/.github/workflows/npm-sdk-publish.yml
@@ -17,7 +17,6 @@ jobs:
           cache: yarn
       - run: |
           npm config set ${REGISTRY}:_authToken ${{ secrets.NPM_PACKAGE_TOKEN }}
-          npm config set @delandlabs:registry https:${REGISTRY}
         env:
           REGISTRY: //registry.npmjs.org/
       - run: |


### PR DESCRIPTION
## Problem
The npm publish workflow may be failing due to conflicting registry configurations. The workflow sets:
```bash
npm config set @delandlabs:registry https://registry.npmjs.org/
```

But this might conflict with publishing packages using `--access public` flag.

## Solution
Remove the `@delandlabs:registry` configuration line, keeping only the auth token configuration.

## Why this might fix the issue
1. The packages are already using `--access public` flag
2. Setting a scoped registry might interfere with public publishing
3. The auth token is sufficient for authentication

## Test Plan
- [ ] Verify NPM_PACKAGE_TOKEN has proper permissions
- [ ] Packages should publish successfully to npm public registry
- [ ] No permission errors during publish

## Related
- Failed workflow: https://github.com/Deland-Labs/hibit-id-sdk/actions/runs/16367981400

🤖 Generated with [Claude Code](https://claude.ai/code)