### PR TITLE
fix: correct npm badge URL to use registry.npmjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hibit ID SDK
 
-[![npm version](https://img.shields.io/npm/v/@delandlabs/hibit-id-sdk)](https://www.npmjs.com/package/@delandlabs/hibit-id-sdk)
+[![npm version](https://img.shields.io/npm/v/@delandlabs/hibit-id-sdk)](https://registry.npmjs.org/@delandlabs/hibit-id-sdk)
 [![Build Status](https://github.com/deland-labs/hibit-id-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/deland-labs/hibit-id-sdk/actions)
 [![Test Status](https://img.shields.io/github/actions/workflow/status/deland-labs/hibit-id-sdk/test.yml?label=tests)](https://github.com/deland-labs/hibit-id-sdk/actions)
 [![License](https://img.shields.io/github/license/deland-labs/hibit-id-sdk)](LICENSE)


### PR DESCRIPTION
## Summary
Fixed the npm badge URL in README.md to use the correct registry.npmjs.org domain.

## Changes
- Changed npm badge link from `https://www.npmjs.com/package/@delandlabs/hibit-id-sdk` to `https://registry.npmjs.org/@delandlabs/hibit-id-sdk`

## Why this change?
The CI pipeline was failing because it expects the npm badge to link to registry.npmjs.org, not www.npmjs.com.

## Test Plan
- [x] Verified the new URL is correct and accessible
- [x] CI checks should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)