### PR TITLE
fix: correct SDK package name to @delandlabs/hibit-id-sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hibit-id-sdk",
+  "name": "@delandlabs/hibit-id-sdk",
   "private": false,
   "version": "1.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
Fixed the package name in packages/sdk/package.json to match the published npm package.

## Changes
- Changed `"name": "hibit-id-sdk"` to `"name": "@delandlabs/hibit-id-sdk"` in packages/sdk/package.json

## Why this change?
The CI pipeline was failing because the package name in package.json didn't match the published npm package name @delandlabs/hibit-id-sdk.

## Test Plan
- [x] Verified the package name matches npm registry
- [x] CI checks should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)