### PR TITLE
fix: add fetch-depth to GitLab workflow to get tags

### DIFF
--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
Fix the GitLab workflow failing with "No names found, cannot describe anything" error.

## Problem
The `git describe --tags --abbrev=0` command in the GitLab workflow was failing because GitHub Actions doesn't fetch tags by default with shallow clones.

## Solution
Added `fetch-depth: 0` to the checkout action to fetch all history and tags.

## Related Issues
- Fixes the workflow failure from PR #366
- Error log: https://github.com/Deland-Labs/hibit-id-sdk/actions/runs/16369626237/job/46254706531

🤖 Generated with [Claude Code](https://claude.ai/code)