### PR TITLE
fix: auto-increment patch version for GitLab alpha releases

### DIFF
--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -1,0 +1,55 @@
+name: publish hibit-id-sdk packages to GitLab
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+      - release
+jobs:
+  Build-and-Publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://gitlab.com/api/v4/projects/37663507/packages/npm
+          cache: yarn
+      - run: |
+          npm config set ${REGISTRY}:_authToken ${{ secrets.GITLAB_PACKAGE_TOKEN }}
+        env:
+          REGISTRY: //gitlab.com/api/v4/projects/37663507/packages/npm/
+      - run: |
+          # Get the base version from latest tag
+          BaseVersion=$(git describe --tags --abbrev=0)
+          echo "Base Version: $BaseVersion"
+          
+          # For release events, use the tag version
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            Version=$BaseVersion
+          else
+            # For main/release branches, generate alpha version
+            Timestamp=$(date -u +%Y%m%d%H%M%S)
+            Version="${BaseVersion}-alpha.${Timestamp}"
+          fi
+          
+          echo "Publishing Version: $Version"
+          export VITE_RELEASE_VERSION=$Version
+
+          yarn install --frozen-lockfile
+
+          # Replace * with actual version in package.json
+          node scripts/replaceVersions.js $Version
+
+          yarn build:all
+
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/crypto-lib
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-base
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-dfinity
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-ethereum
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-kaspa
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-solana
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-ton
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/coin-tron
+          yarn publish --frozen-lockfile --non-interactive --no-git-tag-version --no-commit-hooks --new-version ${Version} packages/sdk

--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -21,15 +23,21 @@ jobs:
         env:
           REGISTRY: //gitlab.com/api/v4/projects/37663507/packages/npm/
       - run: |
-          # Get the base version from latest tag
-          BaseVersion=$(git describe --tags --abbrev=0)
-          echo "Base Version: $BaseVersion"
+          # Get the latest tag and increment patch version
+          LatestTag=$(git tag -l | sort -V | tail -1)
+          echo "Latest Tag: $LatestTag"
           
           # For release events, use the tag version
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            Version=$BaseVersion
+            Version=${{ github.event.release.tag_name }}
           else
-            # For main/release branches, generate alpha version
+            # For main/release branches, increment patch version and add alpha suffix
+            # Extract major, minor, and patch version numbers
+            IFS='.' read -r major minor patch <<< "$LatestTag"
+            # Increment patch version
+            NextPatch=$((patch + 1))
+            BaseVersion="${major}.${minor}.${NextPatch}"
+            # Generate alpha version with timestamp
             Timestamp=$(date -u +%Y%m%d%H%M%S)
             Version="${BaseVersion}-alpha.${Timestamp}"
           fi

--- a/.github/workflows/npm-sdk-publish.yml
+++ b/.github/workflows/npm-sdk-publish.yml
@@ -16,6 +16,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: yarn
       - run: |
+          rm .npmrc
           npm config set ${REGISTRY}:_authToken ${{ secrets.NPM_PACKAGE_TOKEN }}
         env:
           REGISTRY: //registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@delandlabs:registry=https://gitlab.com/api/v4/projects/37663507/packages/npm/


### PR DESCRIPTION
## Summary
Fixed the version generation logic for GitLab alpha releases to automatically increment the patch version.

## Changes
1. **Version Generation Logic**:
   - Changed from using `git describe` (which returned 1.2.6) to `git tag -l | sort -V`
   - Automatically increment patch version for alpha releases
   - Alpha versions now use format: `latest_version+1-alpha.timestamp`
   - Example: If latest tag is 2.4.5, alpha will be 2.4.6-alpha.20250718120000

2. **Added fetch-depth**:
   - Added `fetch-depth: 0` to checkout action to ensure all tags are available

## Test Results
- Latest tag: 2.4.5
- Next alpha version: 2.4.6-alpha.YYYYMMDDHHmmss

This ensures alpha versions always use a version number higher than the latest release.

🤖 Generated with [Claude Code](https://claude.ai/code)