### PR TITLE
fix: auto-increment patch version for GitLab alpha releases

### DIFF
--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -23,15 +23,21 @@ jobs:
         env:
           REGISTRY: //gitlab.com/api/v4/projects/37663507/packages/npm/
       - run: |
-          # Get the base version from latest tag
-          BaseVersion=$(git describe --tags --abbrev=0)
-          echo "Base Version: $BaseVersion"
+          # Get the latest tag and increment patch version
+          LatestTag=$(git tag -l | sort -V | tail -1)
+          echo "Latest Tag: $LatestTag"
           
           # For release events, use the tag version
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            Version=$BaseVersion
+            Version=${{ github.event.release.tag_name }}
           else
-            # For main/release branches, generate alpha version
+            # For main/release branches, increment patch version and add alpha suffix
+            # Extract major, minor, and patch version numbers
+            IFS='.' read -r major minor patch <<< "$LatestTag"
+            # Increment patch version
+            NextPatch=$((patch + 1))
+            BaseVersion="${major}.${minor}.${NextPatch}"
+            # Generate alpha version with timestamp
             Timestamp=$(date -u +%Y%m%d%H%M%S)
             Version="${BaseVersion}-alpha.${Timestamp}"
           fi


### PR DESCRIPTION
## Summary
修复 GitLab 发布工作流的版本号生成问题，使其自动递增补丁版本号。

## 问题
- 当前使用 `git describe` 返回的是 1.2.6 而不是 2.4.5
- 导致 alpha 版本使用了错误的基础版本号

## 解决方案
- 使用 `git tag -l | sort -V | tail -1` 获取最新版本
- 自动递增补丁版本号
- Alpha 版本格式：`最新版本+1-alpha.时间戳`
- 例如：最新标签是 2.4.5，alpha 版本将是 2.4.6-alpha.20250718120000

这确保了 alpha 版本始终使用高于最新发布版本的版本号。

🤖 Generated with [Claude Code](https://claude.ai/code)