### PR TITLE
fix: correct Turbo package references and monorepo naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@delandlabs/hibit-id-sdk",
+  "name": "hibit-id-sdk-monorepo",
   "private": true,
   "scripts": {
     "build:coin-base": "turbo run @delandlabs/coin-base#build",
-    "dev:sdk": "turbo run dev --filter=hibit-id-sdk",
-    "build:sdk": "turbo run hibit-id-sdk#build",
+    "dev:sdk": "turbo run dev --filter=@delandlabs/hibit-id-sdk",
+    "build:sdk": "turbo run @delandlabs/hibit-id-sdk#build",
     "test:coin-kaspa": "turbo run @delandlabs/coin-kaspa#test",
     "build:coin-kaspa": "turbo run @delandlabs/coin-kaspa#build",
     "build:coin-ethereum": "turbo run @delandlabs/coin-ethereum#build",

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,7 @@
       "dependsOn": ["@delandlabs/coin-base#build"],
       "outputs": ["dist/**"]
     },
-    "hibit-id-sdk#build": {
+    "@delandlabs/hibit-id-sdk#build": {
       "env": ["VITE_*"],
       "dependsOn": ["@delandlabs/coin-base#build", "@delandlabs/coin-ton#build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Summary
- Fixed turbo.json to use full package name `@delandlabs/hibit-id-sdk` instead of `hibit-id-sdk`
- Updated build:sdk and dev:sdk scripts to use correct package reference
- Renamed root package.json from `@delandlabs/hibit-id-sdk` to `hibit-id-sdk-monorepo` to avoid naming conflict

## Problem
The `yarn build:sdk` command was failing with error:
```
x Could not find package "hibit-id-sdk" referenced by task "hibit-id-sdk#build" in project
```

## Solution
Turbo requires the full package name including scope when referencing tasks. Since the SDK package is named `@delandlabs/hibit-id-sdk`, all references must use this full name.

Additionally, the root monorepo package.json was using the same name as the SDK package, which could cause confusion. It has been renamed to `hibit-id-sdk-monorepo`.

## Test plan
- [x] Run `yarn build:sdk` - should complete successfully
- [x] Run `yarn dev:sdk` - should work correctly
- [x] Verify other build commands still work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package naming conventions and script commands for improved consistency.
  * Aligned build script configuration with updated package naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->