### PR TITLE
fix: update KasplexL2TestNet network ID to 167012

### DIFF
--- a/packages/coin-base/src/types.ts
+++ b/packages/coin-base/src/types.ts
@@ -87,7 +87,7 @@ export class ChainNetwork {
 
   static KaspaMainNet = new ChainNetwork(0n);
   static KaspaTestNet = new ChainNetwork(1n);
-  static EvmKasplexL2TestNet = new ChainNetwork(0xc655458fn);
+  static EvmKasplexL2TestNet = new ChainNetwork(0x28c64n);
 
   static fromString(value: string): ChainNetwork | null {
     if (!value) {


### PR DESCRIPTION
## Summary
- Updated the KasplexL2TestNet network ID from `0xc655458f` (3327681135) to `0x28c64` (167012)
- This change aligns with the actual network ID returned by the Kasplex L2 testnet RPC endpoint

## Motivation
The network ID mismatch was discovered when querying the RPC endpoint:
```bash
curl -X POST https://rpc.kasplextest.xyz \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}'
```

Response:
```json
{"jsonrpc":"2.0","id":1,"result":"167012"}
```

## Changes
- Modified `packages/coin-base/src/types.ts` to update the `EvmKasplexL2TestNet` network ID

## Test plan
- [x] Successfully built all packages with `yarn build:all`
- [ ] Test wallet connections with the updated network ID
- [ ] Verify transactions work correctly on KasplexL2TestNet

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the network identifier for EvmKasplex L2 TestNet to ensure correct network selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->